### PR TITLE
增加了一些功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,38 @@
-# emby-pinyin
+# Emby-pinyin-custom
 
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/wushuo894/emby-pinyin/maven.yml?branch=master)](https://github.com/wushuo894/emby-pinyin/actions/workflows/maven.yml)
 [![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/wushuo894/emby-pinyin?color=blue&label=download&sort=semver)](https://github.com/wushuo894/EmbyPinyin/releases/latest)
 [![GitHub all releases](https://img.shields.io/github/downloads/wushuo894/emby-pinyin/total?color=blue&label=github%20downloads)](https://github.com/wushuo894/emby-pinyin/releases)
 [![Docker Pulls](https://img.shields.io/docker/pulls/wushuo894/emby-pinyin)](https://hub.docker.com/r/wushuo894/emby-pinyin)
 
-Emby 支持拼音首字母排序
 
-![screenshot.png](https://raw.githubusercontent.com/wushuo894/emby-pinyin/master/images/screenshot.png#gh-light-mode-only)
-![screenshot-dark.png](https://raw.githubusercontent.com/wushuo894/emby-pinyin/master/images/screenshot-dark.png#gh-dark-mode-only)
 
+
+## 功能介绍
+   
+ ### 🔤 改名模式
+为 Emby 提供多种拼音首字母排序方式：
+| 模式 | 示例 |
+|------|------|
+| 全拼 | chu men de shi jie |
+| 首字母 | c m d s j |
+| 前置字母 | c_楚门的世界 |
+| 默认 | 楚门的世界 |
+
+ ### 🔒 锁定规则
+
+在排序标题末尾添加：“ #lock”  
+该项目将跳过自动修改
+
+| 模式 | 示例 |
+|------|------|
+| 楚门的世界#lock | ✅ |
+| 楚门的世界 #lock | ✅ |
+| 楚门的世界   #lock | ✅ |
+| 楚门的世界 #LOCK | ✅ |  
+
+
+使用实例1：在合集中新建片单合集并置顶
 ## Docker部署
 
     docker run -d \
@@ -35,3 +58,6 @@ Emby 支持拼音首字母排序
 | 请求类型   | application/json          |
 | Events | 媒体库/新媒体已添加                |
 
+## 图片预览
+![screenshot.png](https://raw.githubusercontent.com/wushuo894/emby-pinyin/master/images/screenshot.png#gh-light-mode-only)
+![screenshot-dark.png](https://raw.githubusercontent.com/wushuo894/emby-pinyin/master/images/screenshot-dark.png#gh-dark-mode-only)

--- a/emby-pinyin-application/src/main/java/emby/pinyin/enums/PinyinMode.java
+++ b/emby-pinyin-application/src/main/java/emby/pinyin/enums/PinyinMode.java
@@ -1,5 +1,8 @@
 package emby.pinyin.enums;
 
 public enum PinyinMode {
-    PINYIN, FIRST_LETTER
+    PINYIN,         // 全拼，例如 "世界" → "shijie"
+    FIRST_LETTER,   // 首字母，例如 "世界" → "sj"
+    PREFIX,         // 前置字母，例如 "世界" → "s_世界"
+    DEFAULT         // Emby默认，例如 "世界" → "世界"（使用原始名称并锁定）
 }

--- a/emby-pinyin-application/src/main/java/emby/pinyin/util/EmbyUtil.java
+++ b/emby-pinyin-application/src/main/java/emby/pinyin/util/EmbyUtil.java
@@ -93,23 +93,60 @@ public class EmbyUtil {
                     }
                     String name = body.get("Name").getAsString();
 
+                    // 优先从排序标题判断 #lock（更符合实际用途）
+                    String sortName = body.has("SortName") && !body.get("SortName").isJsonNull()
+                            ? body.get("SortName").getAsString()
+                            : "";
+
+                    String checkTarget = StrUtil.isNotBlank(sortName) ? sortName : name;
+                    String lower = checkTarget.toLowerCase().trim();
+
+                    // 跳过带有 #lock 标记的项目（支持 xxx#lock 和 xxx #lock）
+                    if (lower.endsWith("#lock")) {
+                        log.debug("skip (locked): {}", checkTarget);
+                        return body;
+                    }
+
                     String pinyin = "";
 
                     PinyinMode pinyinMode = config.getPinyinMode();
+
+                    // 根据不同模式生成排序字段（SortName）
                     if (pinyinMode == PinyinMode.PINYIN) {
+                        // 模式1：全拼，例如 "世界" → "shijie"
                         pinyin = PinyinUtils.getPinyin(name, " ").toLowerCase();
+
+                    } else if (pinyinMode == PinyinMode.FIRST_LETTER) {
+                        // 模式2：首字母，例如 "世界" → "sj"
+                        pinyin = PinyinUtils.getFirstLetter(name, " ").toLowerCase();
+
+                    } else if (pinyinMode == PinyinMode.PREFIX) {
+                        // 模式3：前置字母，例如 "世界" → "s_世界"
+                        String first = PinyinUtils.getFirstLetter(name, "");
+                        String initial = (first != null && first.length() > 0)
+                                ? first.substring(0, 1).toLowerCase()
+                                : "";
+                        pinyin = initial + "_" + name;
+
+                    } else if (pinyinMode == PinyinMode.DEFAULT) {
+                        // 模式4：Emby默认
+                        // 这里不再删除字段，而是直接使用原始名称作为排序
+                        pinyin = name;
                     }
 
-                    if (pinyinMode == PinyinMode.FIRST_LETTER) {
-                        pinyin = PinyinUtils.getFirstLetter(name, " ").toLowerCase();
-                    }
                     log.debug("name: {} , pinyin: {}", name, pinyin);
-                    body.addProperty("SortName", pinyin);
-                    body.addProperty("ForcedSortName", pinyin);
-                    JsonArray lockedFields = body.get("LockedFields").getAsJsonArray();
-                    lockedFields.asList()
-                            .clear();
-                    lockedFields.add("SortName");
+
+                    if (StrUtil.isNotBlank(pinyin)) {
+                        // 统一写入排序字段（所有模式都会写入并锁定）
+                        body.addProperty("SortName", pinyin);
+                        body.addProperty("ForcedSortName", pinyin);
+
+                        // 锁定排序字段，防止被 Emby 或其他工具覆盖
+                        JsonArray lockedFields = body.get("LockedFields").getAsJsonArray();
+                        lockedFields.asList().clear();
+                        lockedFields.add("SortName");
+                    }
+
                     return body;
                 });
         if (Objects.isNull(jsonObject)) {


### PR DESCRIPTION
## ✨ 功能说明

- 增加 “前置字母” 的排序方式，（例： ”x_新世界“） 这种排序方式的优点是首字相同的排在一起，再按音调排列（如“完”“宛”“万”的顺序），增加了查找首字的效率。


<img width="1061" height="611" alt="截屏2026-04-07 17 16 00" src="https://github.com/user-attachments/assets/30f10ca4-1637-4ad6-bc3c-99f609601cc1" />


- 增加“Emby默认”的排序方式，应对一些需要还原的场景。

- 增加对 `#lock` 标记的支持，用于跳过自动排序名称（SortName）的修改。  

  使用场景1: 用合集新建片单的时候可以用到，emby官方的主屏幕区块里，合集那项是根据排序标题排序的，所以可以做一些例如top250，金马金像金鸡之类的片单出现在首页，方便观看，这时候就需要锁定更改排序名称。

<img width="1009" height="361" alt="截屏2026-04-07 17 09 09" src="https://github.com/user-attachments/assets/dffec6be-2563-4a8c-b29f-8fae6860720a" />    

  使用场景2: 一些系列电影的排序，比如说哈利波特系列，因为名称里没有明确的123的排序，有时为了便于观看，会手动在排序标题里添加序号，比如说改为“h_哈利·波特1与魔法石”，“h_哈利·波特2与密室 ”，这种时候也需要锁定更改排序名称，以免打乱排序。